### PR TITLE
update reset password page

### DIFF
--- a/src/pages/ResetPassword.jsx
+++ b/src/pages/ResetPassword.jsx
@@ -1,7 +1,54 @@
-import React from "react";
+import React, { useState } from "react";
+import { getAuth, sendPasswordResetEmail } from "firebase/auth";
 
 const ResetPassword = () => {
-  return <div>ResetPassword</div>;
+  const auth=getAuth () ;
+  const [showModal, setShowModal] = useState(false);
+
+  function resetPassword() {
+    const email = document.getElementById('email').value;
+    sendPasswordResetEmail(auth, email).then(() => {
+      setShowModal(true);
+    }).catch((error) => {
+      console.error(error);
+    });
+  }
+
+  const Modal = ({ onClose }) => (
+    <div style={{
+      position: 'fixed',
+      top: '50%',
+      left: '50%',
+      transform: 'translate(-50%, -50%)',
+      backgroundColor: 'white',
+      padding: '20px',
+      zIndex: 1000,
+    }}>
+      <h2>Check your email</h2>
+      <p>Please check your email inbox and spam folder for a verification email to reset your password.</p>
+      <button onClick={onClose}>Cancel</button>
+      <button onClick={onClose}>Understood</button>
+    </div>
+  );
+  return <div style={{textAlign:'center',paddingTop:'50px'}}>
+  <div style={{maxWidth:'400px',margin:'auto'}}>
+      <h1 style={{marginBottom:'50px'}}>Reset your password</h1>
+      <img src="./logo.png" alt="Logo" style={{width:'100px',height:'auto',marginBottom:'20px'}}/>
+      <div style={{marginBottom:'20px'}}>
+          <input type="email" id="email" placeholder="Write your e-mail registered" style={{padding:'10px','width':'100%'}}/>
+      </div>
+      <button onClick={resetPassword} style={{padding:'10px',width:'100%',backgroundColor:'#48801c',color:'white',borderRadius:'20px'}}>Reset</button>
+  </div>
+  {showModal && (
+        <div style={{position: 'fixed',zIndex: '1',paddingTop: '100px',left: '0',top: '0',width: '100%',height: '100%',overflow: 'auto',backgroundColor: 'rgb(0,0,0)',backgroundColor: 'rgba(0,0,0,0.4)'}}>
+          <div style={{backgroundColor: '#fefefe',margin: 'auto',padding: '20px',border: '1px solid #888',width: '80%',boxShadow: '0 4px 8px 0 rgba(0,0,0,0.2)',animationName: 'animatetop',animationDuration: '0.4s'}}>
+            <h2 style={{color: '#023268'}}>Check your email</h2>
+            <p>Please check your email inbox and spam folder for a verification email to reset your password.</p>
+            <button onClick={() => setShowModal(false)} style={{ backgroundColor: '#48801c', color: 'white', padding: '10px 20px', margin: '10px 0', borderRadius:'20px'}}>Understood</button>
+          </div>
+        </div>
+      )}
+</div>
 };
 
 export default ResetPassword;

--- a/src/pages/ResetPassword.jsx
+++ b/src/pages/ResetPassword.jsx
@@ -1,5 +1,9 @@
 import React, { useState } from "react";
 import { getAuth, sendPasswordResetEmail } from "firebase/auth";
+import {
+  Typography,
+} from "@mui/material";
+
 
 const ResetPassword = () => {
   const auth=getAuth () ;
@@ -32,17 +36,19 @@ const ResetPassword = () => {
   );
   return <div style={{textAlign:'center',paddingTop:'50px'}}>
   <div style={{maxWidth:'400px',margin:'auto'}}>
-      <h1 style={{marginBottom:'50px'}}>Reset your password</h1>
+      <Typography component="h1" variant="h5" >         
+        Reset your password
+      </Typography>
       <img src="./logo.png" alt="Logo" style={{width:'100px',height:'auto',marginBottom:'20px'}}/>
       <div style={{marginBottom:'20px'}}>
-          <input type="email" id="email" placeholder="Write your e-mail registered" style={{padding:'10px','width':'100%'}}/>
+          <input type="email" id="email" placeholder="Write your e-mail registered" style={{padding:'10px','width':'100%', marginBottom: '60px'}}/>
       </div>
       <button onClick={resetPassword} style={{padding:'10px',width:'100%',backgroundColor:'#48801c',color:'white',borderRadius:'20px'}}>Reset</button>
   </div>
   {showModal && (
         <div style={{position: 'fixed',zIndex: '1',paddingTop: '100px',left: '0',top: '0',width: '100%',height: '100%',overflow: 'auto',backgroundColor: 'rgb(0,0,0)',backgroundColor: 'rgba(0,0,0,0.4)'}}>
           <div style={{backgroundColor: '#fefefe',margin: 'auto',padding: '20px',border: '1px solid #888',width: '80%',boxShadow: '0 4px 8px 0 rgba(0,0,0,0.2)',animationName: 'animatetop',animationDuration: '0.4s'}}>
-            <h2 style={{color: '#023268'}}>Check your email</h2>
+            <h3 style={{color: '#023268'}}>Check your email</h3>
             <p>Please check your email inbox and spam folder for a verification email to reset your password.</p>
             <button onClick={() => setShowModal(false)} style={{ backgroundColor: '#48801c', color: 'white', padding: '10px 20px', margin: '10px 0', borderRadius:'20px'}}>Understood</button>
           </div>


### PR DESCRIPTION
# What
This PR fixes the reset-password functionality according to [this Figma](https://www.figma.com/file/YUSzIpe3cCxEtcxJ030748/Murphy-Foundation?type=design&node-id=19-1372&mode=design) except for the back button which is missing from most other pages as well. Here's how the forget password page looks like using this PR:
<img width="376" alt="Screenshot 2024-03-02 at 11 04 03 PM" src="https://github.com/murphy-charitable-foundation/magic-chat-app-web/assets/31979020/66c51794-42a7-44a2-9bb5-82d8e1863bf3"> <img width="375" alt="Screenshot 2024-03-02 at 11 06 09 PM" src="https://github.com/murphy-charitable-foundation/magic-chat-app-web/assets/31979020/cd598494-31b8-450e-afd4-98007129c8e6">
The HTML of the forget password email is still using the default text on firebase, i.e.,
```
Hello,

Follow this link to reset your Murphys-Charity-Penpal password for your %EMAIL% account.

https://penpalmagicapp.firebaseapp.com/__/auth/action?mode=resetPassword&oobCode={...code...}

If you didn’t ask to reset your password, you can ignore this email.

Thanks,

Your Murphys-Charity-Penpal team
```